### PR TITLE
Revert "Fix Dockerfile" - do not run unprivileged containers as root.

### DIFF
--- a/mainline/alpine-perl/Dockerfile
+++ b/mainline/alpine-perl/Dockerfile
@@ -151,6 +151,6 @@ EXPOSE 8080
 
 STOPSIGNAL SIGTERM
 
-USER root
+USER nginx
 
 CMD ["nginx", "-g", "daemon off;"]

--- a/mainline/alpine/Dockerfile
+++ b/mainline/alpine/Dockerfile
@@ -146,6 +146,6 @@ EXPOSE 8080
 
 STOPSIGNAL SIGTERM
 
-USER root
+USER nginx
 
 CMD ["nginx", "-g", "daemon off;"]

--- a/mainline/stretch-perl/Dockerfile
+++ b/mainline/stretch-perl/Dockerfile
@@ -105,6 +105,6 @@ EXPOSE 8080
 
 STOPSIGNAL SIGTERM
 
-USER root
+USER nginx
 
 CMD ["nginx", "-g", "daemon off;"]

--- a/mainline/stretch/Dockerfile
+++ b/mainline/stretch/Dockerfile
@@ -104,6 +104,6 @@ EXPOSE 8080
 
 STOPSIGNAL SIGTERM
 
-USER root
+USER nginx
 
 CMD ["nginx", "-g", "daemon off;"]

--- a/stable/alpine-perl/Dockerfile
+++ b/stable/alpine-perl/Dockerfile
@@ -151,6 +151,6 @@ EXPOSE 8080
 
 STOPSIGNAL SIGTERM
 
-USER root
+USER nginx
 
 CMD ["nginx", "-g", "daemon off;"]

--- a/stable/alpine/Dockerfile
+++ b/stable/alpine/Dockerfile
@@ -146,6 +146,6 @@ EXPOSE 8080
 
 STOPSIGNAL SIGTERM
 
-USER root
+USER nginx
 
 CMD ["nginx", "-g", "daemon off;"]

--- a/stable/stretch-perl/Dockerfile
+++ b/stable/stretch-perl/Dockerfile
@@ -105,6 +105,6 @@ EXPOSE 8080
 
 STOPSIGNAL SIGTERM
 
-USER root
+USER nginx
 
 CMD ["nginx", "-g", "daemon off;"]

--- a/stable/stretch/Dockerfile
+++ b/stable/stretch/Dockerfile
@@ -104,6 +104,6 @@ EXPOSE 8080
 
 STOPSIGNAL SIGTERM
 
-USER root
+USER nginx
 
 CMD ["nginx", "-g", "daemon off;"]


### PR DESCRIPTION
This reverts commit d68ed10bd0ddc54503027efc66d0d5b141755ff9.

Running the container as root is contrary to the purpose of this Docker image; see the first line of the README.