### PR TITLE
Runs the docker container as user 1001 (unpriveleged) and group 0 (root)

### DIFF
--- a/mainline/alpine-perl/Dockerfile
+++ b/mainline/alpine-perl/Dockerfile
@@ -51,8 +51,7 @@ RUN GPG_KEYS=B0F4253373F8F6F510D42178520A9993A1C052F8 \
 		--with-file-aio \
 		--with-http_v2_module \
 	" \
-	&& addgroup -S nginx \
-	&& adduser -D -S -h /var/cache/nginx -s /sbin/nologin -G nginx nginx \
+	&& adduser -D -S -h /var/cache/nginx -s /sbin/nologin --uid 1001 nginx \
 	&& apk add --no-cache --virtual .build-deps \
 		gcc \
 		libc-dev \
@@ -144,13 +143,12 @@ RUN GPG_KEYS=B0F4253373F8F6F510D42178520A9993A1C052F8 \
 COPY nginx.conf /etc/nginx/nginx.conf
 COPY nginx.vh.default.conf /etc/nginx/conf.d/default.conf
 
-RUN chown -R :0 /var/cache/nginx \
-	&& chmod -R g+w /var/cache/nginx
+RUN chown -R 1001:0 /var/cache/nginx /var/log/nginx/ usr/share/nginx/html/
 
 EXPOSE 8080
 
 STOPSIGNAL SIGTERM
 
-USER root
+USER 1001
 
 CMD ["nginx", "-g", "daemon off;"]

--- a/mainline/alpine-perl/Dockerfile
+++ b/mainline/alpine-perl/Dockerfile
@@ -51,7 +51,8 @@ RUN GPG_KEYS=B0F4253373F8F6F510D42178520A9993A1C052F8 \
 		--with-file-aio \
 		--with-http_v2_module \
 	" \
-	&& adduser -D -S -h /var/cache/nginx -s /sbin/nologin --uid 1001 nginx \
+	&& addgroup -S nginx \
+	&& adduser -D -S -h /var/cache/nginx -s /sbin/nologin -G nginx --uid 1001 nginx \
 	&& apk add --no-cache --virtual .build-deps \
 		gcc \
 		libc-dev \
@@ -143,7 +144,7 @@ RUN GPG_KEYS=B0F4253373F8F6F510D42178520A9993A1C052F8 \
 COPY nginx.conf /etc/nginx/nginx.conf
 COPY nginx.vh.default.conf /etc/nginx/conf.d/default.conf
 
-RUN chown -R 1001:0 /var/cache/nginx /var/log/nginx/ usr/share/nginx/html/
+RUN chown -R 1001:0 /var/cache/nginx
 
 EXPOSE 8080
 

--- a/mainline/alpine/Dockerfile
+++ b/mainline/alpine/Dockerfile
@@ -50,7 +50,8 @@ RUN GPG_KEYS=B0F4253373F8F6F510D42178520A9993A1C052F8 \
 		--with-file-aio \
 		--with-http_v2_module \
 	" \
-	&& adduser -D -S -h /var/cache/nginx -s /sbin/nologin --uid 1001 nginx \
+	&& addgroup -S nginx \
+	&& adduser -D -S -h /var/cache/nginx -s /sbin/nologin -G nginx --uid 1001 nginx \
 	&& apk add --no-cache --virtual .build-deps \
 		gcc \
 		libc-dev \
@@ -138,7 +139,7 @@ RUN GPG_KEYS=B0F4253373F8F6F510D42178520A9993A1C052F8 \
 COPY nginx.conf /etc/nginx/nginx.conf
 COPY nginx.vh.default.conf /etc/nginx/conf.d/default.conf
 
-RUN chown -R 1001:0 /var/cache/nginx /var/log/nginx/ usr/share/nginx/html/
+RUN chown -R 1001:0 /var/cache/nginx
 
 EXPOSE 8080
 

--- a/mainline/alpine/Dockerfile
+++ b/mainline/alpine/Dockerfile
@@ -50,8 +50,7 @@ RUN GPG_KEYS=B0F4253373F8F6F510D42178520A9993A1C052F8 \
 		--with-file-aio \
 		--with-http_v2_module \
 	" \
-	&& addgroup -S nginx \
-	&& adduser -D -S -h /var/cache/nginx -s /sbin/nologin -G nginx nginx \
+	&& adduser -D -S -h /var/cache/nginx -s /sbin/nologin --uid 1001 nginx \
 	&& apk add --no-cache --virtual .build-deps \
 		gcc \
 		libc-dev \
@@ -139,13 +138,12 @@ RUN GPG_KEYS=B0F4253373F8F6F510D42178520A9993A1C052F8 \
 COPY nginx.conf /etc/nginx/nginx.conf
 COPY nginx.vh.default.conf /etc/nginx/conf.d/default.conf
 
-RUN chown -R :0 /var/cache/nginx \
-	&& chmod -R g+w /var/cache/nginx
+RUN chown -R 1001:0 /var/cache/nginx /var/log/nginx/ usr/share/nginx/html/
 
 EXPOSE 8080
 
 STOPSIGNAL SIGTERM
 
-USER root
+USER 1001
 
 CMD ["nginx", "-g", "daemon off;"]

--- a/mainline/stretch-perl/Dockerfile
+++ b/mainline/stretch-perl/Dockerfile
@@ -90,7 +90,8 @@ RUN set -x \
 	fi
 
 # implement changes required to run NGINX as an unprivileged user
-RUN chown -R :0 /var/cache/nginx \
+RUN usermod -u 1001 nginx \
+	&& chown -R 1001:0 /var/cache/nginx \
 	&& chmod -R g+w /var/cache/nginx \
 	&& sed -i -e '/listen/!b' -e '/80;/!b' -e 's/80;/8080;/' /etc/nginx/conf.d/default.conf \
 	&& sed -i -e '/user/!b' -e '/nginx/!b' -e '/nginx/d' /etc/nginx/nginx.conf \
@@ -105,6 +106,6 @@ EXPOSE 8080
 
 STOPSIGNAL SIGTERM
 
-USER root
+USER 1001
 
 CMD ["nginx", "-g", "daemon off;"]

--- a/mainline/stretch/Dockerfile
+++ b/mainline/stretch/Dockerfile
@@ -90,7 +90,7 @@ RUN set -x \
 
 # implement changes required to run NGINX as an unprivileged user
 RUN usermod -u 1001 nginx \
-	chown -R 1001:0 /var/cache/nginx \
+	&& chown -R 1001:0 /var/cache/nginx \
 	&& chmod -R g+w /var/cache/nginx \
 	&& sed -i -e '/listen/!b' -e '/80;/!b' -e 's/80;/8080;/' /etc/nginx/conf.d/default.conf \
 	&& sed -i -e '/user/!b' -e '/nginx/!b' -e '/nginx/d' /etc/nginx/nginx.conf \

--- a/mainline/stretch/Dockerfile
+++ b/mainline/stretch/Dockerfile
@@ -89,7 +89,8 @@ RUN set -x \
 	fi
 
 # implement changes required to run NGINX as an unprivileged user
-RUN chown -R :0 /var/cache/nginx \
+RUN usermod -u 1001 nginx \
+	chown -R 1001:0 /var/cache/nginx \
 	&& chmod -R g+w /var/cache/nginx \
 	&& sed -i -e '/listen/!b' -e '/80;/!b' -e 's/80;/8080;/' /etc/nginx/conf.d/default.conf \
 	&& sed -i -e '/user/!b' -e '/nginx/!b' -e '/nginx/d' /etc/nginx/nginx.conf \
@@ -104,6 +105,6 @@ EXPOSE 8080
 
 STOPSIGNAL SIGTERM
 
-USER root
+USER 1001
 
 CMD ["nginx", "-g", "daemon off;"]

--- a/stable/alpine-perl/Dockerfile
+++ b/stable/alpine-perl/Dockerfile
@@ -51,7 +51,8 @@ RUN GPG_KEYS=B0F4253373F8F6F510D42178520A9993A1C052F8 \
 		--with-file-aio \
 		--with-http_v2_module \
 	" \
-	&& adduser -D -S -h /var/cache/nginx -s /sbin/nologin --uid 1001 nginx \
+	&& addgroup -S nginx \
+	&& adduser -D -S -h /var/cache/nginx -s /sbin/nologin -G nginx --uid 1001 nginx \
 	&& apk add --no-cache --virtual .build-deps \
 		gcc \
 		libc-dev \
@@ -143,7 +144,7 @@ RUN GPG_KEYS=B0F4253373F8F6F510D42178520A9993A1C052F8 \
 COPY nginx.conf /etc/nginx/nginx.conf
 COPY nginx.vh.default.conf /etc/nginx/conf.d/default.conf
 
-RUN chown -R 1001:0 /var/cache/nginx /var/cache/nginx /var/run/ /var/log/nginx/ usr/share/nginx/html/
+RUN chown -R 1001:0 /var/cache/nginx
 
 EXPOSE 8080
 

--- a/stable/alpine-perl/Dockerfile
+++ b/stable/alpine-perl/Dockerfile
@@ -51,8 +51,7 @@ RUN GPG_KEYS=B0F4253373F8F6F510D42178520A9993A1C052F8 \
 		--with-file-aio \
 		--with-http_v2_module \
 	" \
-	&& addgroup -S nginx \
-	&& adduser -D -S -h /var/cache/nginx -s /sbin/nologin -G nginx nginx \
+	&& adduser -D -S -h /var/cache/nginx -s /sbin/nologin --uid 1001 nginx \
 	&& apk add --no-cache --virtual .build-deps \
 		gcc \
 		libc-dev \
@@ -144,13 +143,12 @@ RUN GPG_KEYS=B0F4253373F8F6F510D42178520A9993A1C052F8 \
 COPY nginx.conf /etc/nginx/nginx.conf
 COPY nginx.vh.default.conf /etc/nginx/conf.d/default.conf
 
-RUN chown -R :0 /var/cache/nginx \
-	&& chmod -R g+w /var/cache/nginx
+RUN chown -R 1001:0 /var/cache/nginx /var/cache/nginx /var/run/ /var/log/nginx/ usr/share/nginx/html/
 
 EXPOSE 8080
 
 STOPSIGNAL SIGTERM
 
-USER root
+USER 1001
 
 CMD ["nginx", "-g", "daemon off;"]

--- a/stable/alpine/Dockerfile
+++ b/stable/alpine/Dockerfile
@@ -2,7 +2,7 @@ FROM alpine:3.8
 
 LABEL maintainer="NGINX Docker Maintainers <docker-maint@nginx.com>"
 
-ENV NGINX_VERSION 1.14.0
+ENV NGINX_VERSION=1.14.0
 
 RUN GPG_KEYS=B0F4253373F8F6F510D42178520A9993A1C052F8 \
 	&& CONFIG="\
@@ -50,8 +50,7 @@ RUN GPG_KEYS=B0F4253373F8F6F510D42178520A9993A1C052F8 \
 		--with-file-aio \
 		--with-http_v2_module \
 	" \
-	&& addgroup -S nginx \
-	&& adduser -D -S -h /var/cache/nginx -s /sbin/nologin -G nginx nginx \
+	&& adduser -D -S -h /var/cache/nginx -s /sbin/nologin --uid 1001 nginx \
 	&& apk add --no-cache --virtual .build-deps \
 		gcc \
 		libc-dev \
@@ -139,13 +138,12 @@ RUN GPG_KEYS=B0F4253373F8F6F510D42178520A9993A1C052F8 \
 COPY nginx.conf /etc/nginx/nginx.conf
 COPY nginx.vh.default.conf /etc/nginx/conf.d/default.conf
 
-RUN chown -R :0 /var/cache/nginx \
-	&& chmod -R g+w /var/cache/nginx
+RUN chown -R 1001:0 /var/cache/nginx /var/log/nginx/ usr/share/nginx/html/
 
 EXPOSE 8080
 
 STOPSIGNAL SIGTERM
 
-USER root
+USER 1001
 
 CMD ["nginx", "-g", "daemon off;"]

--- a/stable/alpine/Dockerfile
+++ b/stable/alpine/Dockerfile
@@ -2,7 +2,7 @@ FROM alpine:3.8
 
 LABEL maintainer="NGINX Docker Maintainers <docker-maint@nginx.com>"
 
-ENV NGINX_VERSION=1.14.0
+ENV NGINX_VERSION 1.14.0
 
 RUN GPG_KEYS=B0F4253373F8F6F510D42178520A9993A1C052F8 \
 	&& CONFIG="\
@@ -50,7 +50,8 @@ RUN GPG_KEYS=B0F4253373F8F6F510D42178520A9993A1C052F8 \
 		--with-file-aio \
 		--with-http_v2_module \
 	" \
-	&& adduser -D -S -h /var/cache/nginx -s /sbin/nologin --uid 1001 nginx \
+	&& addgroup -S nginx \
+	&& adduser -D -S -h /var/cache/nginx -s /sbin/nologin -G nginx --uid 1001 nginx \
 	&& apk add --no-cache --virtual .build-deps \
 		gcc \
 		libc-dev \
@@ -138,7 +139,7 @@ RUN GPG_KEYS=B0F4253373F8F6F510D42178520A9993A1C052F8 \
 COPY nginx.conf /etc/nginx/nginx.conf
 COPY nginx.vh.default.conf /etc/nginx/conf.d/default.conf
 
-RUN chown -R 1001:0 /var/cache/nginx /var/log/nginx/ usr/share/nginx/html/
+RUN chown -R 1001:0 /var/cache/nginx
 
 EXPOSE 8080
 

--- a/stable/stretch-perl/Dockerfile
+++ b/stable/stretch-perl/Dockerfile
@@ -91,7 +91,7 @@ RUN set -x \
 
 # implement changes required to run NGINX as an unprivileged user
 RUN usermod -u 1001 nginx \
-	chown -R 1001:0 /var/cache/nginx \
+	&& chown -R 1001:0 /var/cache/nginx \
 	&& chmod -R g+w /var/cache/nginx \
 	&& sed -i -e '/listen/!b' -e '/80;/!b' -e 's/80;/8080;/' /etc/nginx/conf.d/default.conf \
 	&& sed -i -e '/user/!b' -e '/nginx/!b' -e '/nginx/d' /etc/nginx/nginx.conf \

--- a/stable/stretch-perl/Dockerfile
+++ b/stable/stretch-perl/Dockerfile
@@ -90,7 +90,8 @@ RUN set -x \
 	fi
 
 # implement changes required to run NGINX as an unprivileged user
-RUN chown -R :0 /var/cache/nginx \
+RUN usermod -u 1001 nginx \
+	chown -R 1001:0 /var/cache/nginx \
 	&& chmod -R g+w /var/cache/nginx \
 	&& sed -i -e '/listen/!b' -e '/80;/!b' -e 's/80;/8080;/' /etc/nginx/conf.d/default.conf \
 	&& sed -i -e '/user/!b' -e '/nginx/!b' -e '/nginx/d' /etc/nginx/nginx.conf \
@@ -105,6 +106,6 @@ EXPOSE 8080
 
 STOPSIGNAL SIGTERM
 
-USER root
+USER 1001
 
 CMD ["nginx", "-g", "daemon off;"]

--- a/stable/stretch/Dockerfile
+++ b/stable/stretch/Dockerfile
@@ -90,7 +90,7 @@ RUN set -x \
 
 # implement changes required to run NGINX as an unprivileged user
 RUN usermod -u 1001 nginx \
-	chown -R 1001:0 /var/cache/nginx \
+	&& chown -R 1001:0 /var/cache/nginx \
 	&& chmod -R g+w /var/cache/nginx \
 	&& sed -i -e '/listen/!b' -e '/80;/!b' -e 's/80;/8080;/' /etc/nginx/conf.d/default.conf \
 	&& sed -i -e '/user/!b' -e '/nginx/!b' -e '/nginx/d' /etc/nginx/nginx.conf \

--- a/stable/stretch/Dockerfile
+++ b/stable/stretch/Dockerfile
@@ -89,7 +89,8 @@ RUN set -x \
 	fi
 
 # implement changes required to run NGINX as an unprivileged user
-RUN chown -R :0 /var/cache/nginx \
+RUN usermod -u 1001 nginx \
+	chown -R 1001:0 /var/cache/nginx \
 	&& chmod -R g+w /var/cache/nginx \
 	&& sed -i -e '/listen/!b' -e '/80;/!b' -e 's/80;/8080;/' /etc/nginx/conf.d/default.conf \
 	&& sed -i -e '/user/!b' -e '/nginx/!b' -e '/nginx/d' /etc/nginx/nginx.conf \
@@ -104,6 +105,6 @@ EXPOSE 8080
 
 STOPSIGNAL SIGTERM
 
-USER root
+USER 1001
 
 CMD ["nginx", "-g", "daemon off;"]


### PR DESCRIPTION
### What does this commit/MR/PR do?

- Runs the docker container as user 1001 (unpriveleged) and group 0
(root)

###  Why is this commit/MR/PR needed?

- Not to run as root
- Not to run as nginx but an arbitrary user id
- Facilitate kubernetes security context

###  TODO

- [x] Implement similar logic for debian images