### PR TITLE
Check for whitespace before port to ensure port 80 is only replaced

### DIFF
--- a/stable/alpine/30-configure-nginx-unprivileged.sh
+++ b/stable/alpine/30-configure-nginx-unprivileged.sh
@@ -3,7 +3,7 @@
 set -e
 
 # implement changes required to run NGINX as an unprivileged user
-sed -i -e '/listen/!b' -e '/80;/!b' -e 's/80;/8080;/' /etc/nginx/conf.d/default.conf \
+sed -i -e '/listen/!b' -e '/\s80;/!b' -e 's/80;/8080;/' /etc/nginx/conf.d/default.conf \
 && sed -i -e '/user/!b' -e '/nginx/!b' -e '/nginx/d' /etc/nginx/nginx.conf \
 && sed -i 's!/var/run/nginx.pid!/tmp/nginx.pid!g' /etc/nginx/nginx.conf \
 && sed -i "/^http {/a \    proxy_temp_path /tmp/proxy_temp;\n    client_body_temp_path /tmp/client_temp;\n    fastcgi_temp_path /tmp/fastcgi_temp;\n    uwsgi_temp_path /tmp/uwsgi_temp;\n    scgi_temp_path /tmp/scgi_temp;\n" /etc/nginx/nginx.conf


### PR DESCRIPTION
Resolves #37 

Will make sure it does not rewrite user defining port 8080 if user uploads their own default.conf file in their Dockerfile reference.