### PR TITLE
Fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,4 +29,4 @@ Most images are built for the `amd64`, `arm32v5` (for Debian), `arm32v6` (for Al
 
 ## Common Issues
 
-* If you overrive the default `nginx.conf` file you may receive the message `nginx: [emerg] open() "/var/run/nginx.pid" failed (13: Permission denied)`, in this case you have to add the line `pid /tmp/nginx.pid` into your config.
+* If you override the default `nginx.conf` file you may receive the message `nginx: [emerg] open() "/var/run/nginx.pid" failed (13: Permission denied)`, in this case you have to add the line `pid /tmp/nginx.pid` into your config.


### PR DESCRIPTION
Fix nginxinc/docker-nginx-unprivileged#131

### Proposed changes

Describe the use case and detail of the change. If this PR addresses an issue on GitHub, make sure to include a link to that issue using one of the [supported keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) here in this description (not in the title of the PR).

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x ] I have read the [`CONTRIBUTING`](https://github.com/nginxinc/docker-nginx-unprivileged/blob/main/CONTRIBUTING.md) document.
- [ x] I have tested that the NGINX Unprivileged Docker images build correctly on all supported platforms (check out the [`README`](https://github.com/nginxinc/docker-nginx-unprivileged/blob/main/README.md) for more details).
- [x ] I have deployed the NGINX Unprivileged Docker images on an unprivileged environment and checked that they run correctly.
- [x ] I have updated any relevant documentation ([`README`](https://github.com/nginxinc/docker-nginx-unprivileged/blob/main/README.md))
