### PR TITLE
Cleanup/remove untagged Amazon Public ECR images when new images are built

### DIFF
--- a/.github/workflows/alpine-mainline.yml
+++ b/.github/workflows/alpine-mainline.yml
@@ -372,4 +372,4 @@ jobs:
 
       - name: Delete untagged Alpine NGINX mainline Docker images on the Amazon ECR Public Gallery
         run: |
-          ./scripts/delete-untagged-amazon-public-ecr-images.sh
+          .github/workflows/scripts/delete-untagged-amazon-public-ecr-images.sh

--- a/.github/workflows/alpine-mainline.yml
+++ b/.github/workflows/alpine-mainline.yml
@@ -14,6 +14,12 @@ jobs:
       patch: ${{ steps.nginx_version.outputs.patch }}
       distro: ${{ steps.distro_version.outputs.release }}
     steps:
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-region: ${{ secrets.AWS_REGION }}
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
       - name: Cleanup AWS ECR
         run: |
           REPOSITORY_NAME=nginx-unprivileged
@@ -30,10 +36,10 @@ jobs:
             --repository-name $REPOSITORY_NAME \
             --image-ids $IMAGE_DIGESTS \
             --dry-run
-        env:
-          aws-region: ${{ secrets.AWS_REGION }}
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        # env:
+        #   aws-region: ${{ secrets.AWS_REGION }}
+        #   aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        #   aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
 
       - name: Check out the codebase
         uses: actions/checkout@v4

--- a/.github/workflows/alpine-mainline.yml
+++ b/.github/workflows/alpine-mainline.yml
@@ -372,4 +372,4 @@ jobs:
 
       - name: Delete untagged Alpine NGINX mainline Docker images on the Amazon ECR Public Gallery
         run: |
-          .github/workflows/scripts/delete-untagged-amazon-public-ecr-images.sh
+          ./scripts/delete-untagged-amazon-public-ecr-images.sh

--- a/.github/workflows/alpine-mainline.yml
+++ b/.github/workflows/alpine-mainline.yml
@@ -14,6 +14,27 @@ jobs:
       patch: ${{ steps.nginx_version.outputs.patch }}
       distro: ${{ steps.distro_version.outputs.release }}
     steps:
+      - name: Cleanup AWS ECR
+        run: |
+          REPOSITORY_NAME=nginx-unprivileged
+
+          IMAGES=$(aws ecr-public describe-images \
+            --repository-name $REPOSITORY_NAME \
+            --region us-east-1 | jq -r .imageDetails)
+
+          UNTAGGED_IMAGES=$(jq -r 'map(select(has("imageTags") | not))' <<< $IMAGES)
+
+          IMAGE_DIGESTS=$(jq -r '[.[] | "imageDigest=\(.imageDigest)"] | join(" ")' <<< $UNTAGGED_IMAGES)
+
+          aws ecr-public batch-delete-image \
+            --repository-name $REPOSITORY_NAME \
+            --image-ids $IMAGE_DIGESTS \
+            --dry-run
+        env:
+          aws-region: ${{ secrets.AWS_REGION }}
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+
       - name: Check out the codebase
         uses: actions/checkout@v4
 

--- a/.github/workflows/alpine-mainline.yml
+++ b/.github/workflows/alpine-mainline.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Cleanup AWS ECR
         run: |
           REPOSITORY_NAME=nginx-unprivileged
-          BATCH_DELETE_SIZE=1000
+          BATCH_DELETE_SIZE=100
           function batch_delete {
             while read -r batch; do
                 if [ -z "${batch}" ]; then

--- a/.github/workflows/alpine-mainline.yml
+++ b/.github/workflows/alpine-mainline.yml
@@ -14,65 +14,6 @@ jobs:
       patch: ${{ steps.nginx_version.outputs.patch }}
       distro: ${{ steps.distro_version.outputs.release }}
     steps:
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
-        with:
-          aws-region: ${{ secrets.AWS_REGION }}
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-      - name: Cleanup AWS ECR
-        run: |
-          REPOSITORY_NAME=nginx-unprivileged
-          BATCH_DELETE_SIZE=100
-          function batch_delete {
-            while read -r batch; do
-                if [ -z "${batch}" ]; then
-                    break
-                fi
-
-                echo "Deleting ${batch}"
-                aws ecr-public batch-delete-image \
-                    --repository-name "${REPOSITORY_NAME}" \
-                    --image-ids ${batch}
-
-            done < <(xargs -L ${BATCH_DELETE_SIZE} <<<"$1")
-          }
-          IMAGE_DIGESTS=$(aws ecr-public describe-images \
-            --repository-name "${REPOSITORY_NAME}" \
-            --query 'imageDetails[?!imageTags && (contains(imageManifestMediaType, `manifest.list.v2`) || contains(imageManifestMediaType, `image.index.v1`))].{imageDigest: join(`=`, [`imageDigest`, imageDigest])}' \
-            --output text)
-          batch_delete "${IMAGE_DIGESTS}"
-          IMAGE_DIGESTS=$(aws ecr-public describe-images \
-            --repository-name "${REPOSITORY_NAME}" \
-            --query 'imageDetails[?!imageTags].{imageDigest: join(`=`, [`imageDigest`, imageDigest])}' \
-            --output text)
-          batch_delete "${IMAGE_DIGESTS}"
-
-
-        #   REPOSITORY_NAME=nginx-unprivileged
-
-        #   IMAGE_DIGESTS=$(aws ecr-public describe-images \
-        #     --max-items 100 \
-        #     --repository-name $REPOSITORY_NAME \
-        #     --query 'imageDetails[?!imageTags && (contains(imageManifestMediaType, `manifest.list.v2`) || contains(imageManifestMediaType, `image.index.v1`))].{imageDigest: join(`=`, [`imageDigest`, imageDigest])}' \
-        #     | jq -r '.[]' | join(" "))
-
-        #   # IMAGES=$(aws ecr-public describe-images \
-        #   #   --repository-name $REPOSITORY_NAME \
-        #   #   --region us-east-1 --max-items 100 | jq -r .imageDetails)
-
-        #   # UNTAGGED_IMAGES=$(jq -r 'map(select(has("imageTags") | not))' <<< $IMAGES)
-
-        #   # IMAGE_DIGESTS=$(jq -r '[.[] | "imageDigest=\(.imageDigest)"] | join(" ")' <<< $UNTAGGED_IMAGES)
-
-        #   aws ecr-public batch-delete-image \
-        #     --repository-name $REPOSITORY_NAME \
-        #     --image-ids $IMAGE_DIGESTS
-        # # env:
-        #   aws-region: ${{ secrets.AWS_REGION }}
-        #   aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-        #   aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-
       - name: Check out the codebase
         uses: actions/checkout@v4
 
@@ -87,6 +28,115 @@ jobs:
         id: distro_version
         run: |
           echo "release=$(cat update.sh | grep -m5 '\[mainline\]=' | tail -n1 | cut -d"'" -f2)" >> "$GITHUB_OUTPUT"
+
+  slim:
+    name: Build Alpine NGINX mainline slim Docker image
+    runs-on: ubuntu-22.04
+    strategy:
+      fail-fast: false
+    needs: version
+    steps:
+      - name: Check out the codebase
+        uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-region: ${{ secrets.AWS_REGION }}
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+
+      - name: Login to Amazon ECR
+        uses: aws-actions/amazon-ecr-login@v2
+        with:
+          registry-type: public
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Login to Quay
+        uses: docker/login-action@v3
+        with:
+          registry: quay.io
+          username: ${{ secrets.QUAY_USERNAME }}
+          password: ${{ secrets.QUAY_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: |
+            public.ecr.aws/nginx/nginx-unprivileged
+            docker.io/nginxinc/nginx-unprivileged
+            ghcr.io/nginxinc/nginx-unprivileged
+            quay.io/nginx/nginx-unprivileged
+          tags: |
+            type=raw,value=${{ needs.version.outputs.major }}.${{ needs.version.outputs.minor }}.${{ needs.version.outputs.patch }}-alpine-slim
+            type=raw,value=${{ needs.version.outputs.major }}.${{ needs.version.outputs.minor }}.${{ needs.version.outputs.patch }}-alpine${{ needs.version.outputs.distro }}-slim
+            type=raw,value=${{ needs.version.outputs.major }}.${{ needs.version.outputs.minor }}-alpine-slim
+            type=raw,value=${{ needs.version.outputs.major }}.${{ needs.version.outputs.minor }}-alpine${{ needs.version.outputs.distro }}-slim
+            type=raw,value=${{ needs.version.outputs.major }}-alpine-slim
+            type=raw,value=${{ needs.version.outputs.major }}-alpine${{ needs.version.outputs.distro }}-slim
+            type=raw,value=mainline-alpine-slim
+            type=raw,value=mainline-alpine${{ needs.version.outputs.distro }}-slim
+            type=raw,value=alpine-slim
+            type=raw,value=alpine${{ needs.version.outputs.distro }}-slim
+
+      - name: Build and push NGINX mainline slim Alpine image to Amazon ECR, Docker Hub and GitHub Container Registry
+        id: build
+        uses: docker/build-push-action@v5
+        with:
+          platforms: linux/amd64, linux/arm/v6, linux/arm/v7, linux/arm64, linux/386, linux/ppc64le, linux/s390x
+          context: "{{ defaultContext }}:mainline/alpine-slim"
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          push: true
+          # cache-from: type=gha,scope=alpine-slim
+          # cache-to: type=gha,mode=min,scope=alpine-slim
+
+      - name: Sign Docker Hub Manifest
+        run: |
+          set -ex
+          sudo apt update
+          sudo apt install -y notary
+          mkdir -p ~/.docker/trust/private
+          echo "$DOCKER_CONTENT_TRUST_REPOSITORY_KEY" > ~/.docker/trust/private/$DOCKER_CONTENT_TRUST_REPOSITORY_KEY_ID.key
+          chmod 0400 ~/.docker/trust/private/$DOCKER_CONTENT_TRUST_REPOSITORY_KEY_ID.key
+          docker trust key load ~/.docker/trust/private/$DOCKER_CONTENT_TRUST_REPOSITORY_KEY_ID.key --name nginx
+          DIGEST=$(printf '${{ steps.build.outputs.metadata }}' | jq -r '."containerimage.descriptor".digest' | cut -d ':' -f2)
+          SIZE=$(printf '${{ steps.build.outputs.metadata }}' | jq -r '."containerimage.descriptor".size')
+          export NOTARY_AUTH=$(printf "${{ secrets.DOCKERHUB_USERNAME }}:${{ secrets.DOCKERHUB_TOKEN }}" | base64 -w0)
+          notary -d ~/.docker/trust/ -s https://notary.docker.io addhash docker.io/nginxinc/nginx-unprivileged ${{ needs.version.outputs.major }}.${{ needs.version.outputs.minor }}.${{ needs.version.outputs.patch }}-alpine-slim $SIZE --sha256 $DIGEST --publish --verbose
+          notary -d ~/.docker/trust/ -s https://notary.docker.io addhash docker.io/nginxinc/nginx-unprivileged ${{ needs.version.outputs.major }}.${{ needs.version.outputs.minor }}.${{ needs.version.outputs.patch }}-alpine${{ needs.version.outputs.distro }}-slim $SIZE --sha256 $DIGEST --publish --verbose
+          notary -d ~/.docker/trust/ -s https://notary.docker.io addhash docker.io/nginxinc/nginx-unprivileged ${{ needs.version.outputs.major }}.${{ needs.version.outputs.minor }}-alpine-slim $SIZE --sha256 $DIGEST --publish --verbose
+          notary -d ~/.docker/trust/ -s https://notary.docker.io addhash docker.io/nginxinc/nginx-unprivileged ${{ needs.version.outputs.major }}.${{ needs.version.outputs.minor }}-alpine${{ needs.version.outputs.distro }}-slim $SIZE --sha256 $DIGEST --publish --verbose
+          notary -d ~/.docker/trust/ -s https://notary.docker.io addhash docker.io/nginxinc/nginx-unprivileged ${{ needs.version.outputs.major }}-alpine-slim $SIZE --sha256 $DIGEST --publish --verbose
+          notary -d ~/.docker/trust/ -s https://notary.docker.io addhash docker.io/nginxinc/nginx-unprivileged ${{ needs.version.outputs.major }}-alpine${{ needs.version.outputs.distro }}-slim $SIZE --sha256 $DIGEST --publish --verbose
+          notary -d ~/.docker/trust/ -s https://notary.docker.io addhash docker.io/nginxinc/nginx-unprivileged mainline-alpine-slim $SIZE --sha256 $DIGEST --publish --verbose
+          notary -d ~/.docker/trust/ -s https://notary.docker.io addhash docker.io/nginxinc/nginx-unprivileged mainline-alpine${{ needs.version.outputs.distro }}-slim $SIZE --sha256 $DIGEST --publish --verbose
+          notary -d ~/.docker/trust/ -s https://notary.docker.io addhash docker.io/nginxinc/nginx-unprivileged alpine-slim $SIZE --sha256 $DIGEST --publish --verbose
+          notary -d ~/.docker/trust/ -s https://notary.docker.io addhash docker.io/nginxinc/nginx-unprivileged alpine${{ needs.version.outputs.distro }}-slim $SIZE --sha256 $DIGEST --publish --verbose
+        env:
+          DOCKER_CONTENT_TRUST_REPOSITORY_KEY: ${{ secrets.DOCKER_CONTENT_TRUST_REPOSITORY_KEY }}
+          DOCKER_CONTENT_TRUST_REPOSITORY_KEY_ID: ${{ secrets.DOCKER_CONTENT_TRUST_REPOSITORY_KEY_ID }}
+          DOCKER_CONTENT_TRUST_REPOSITORY_PASSPHRASE: ${{ secrets.DOCKER_CONTENT_TRUST_REPOSITORY_PASSPHRASE }}
+          NOTARY_TARGETS_PASSPHRASE: ${{ secrets.DOCKER_CONTENT_TRUST_REPOSITORY_PASSPHRASE }}
 
   core:
     name: Build Alpine NGINX mainline Docker image
@@ -306,22 +356,13 @@ jobs:
           DOCKER_CONTENT_TRUST_REPOSITORY_PASSPHRASE: ${{ secrets.DOCKER_CONTENT_TRUST_REPOSITORY_PASSPHRASE }}
           NOTARY_TARGETS_PASSPHRASE: ${{ secrets.DOCKER_CONTENT_TRUST_REPOSITORY_PASSPHRASE }}
 
-  slim:
-    name: Build Alpine NGINX mainline slim Docker image
+  cleanup:
+    name: Delete untagged Alpine NGINX mainline Docker images on the Amazon ECR Public Gallery
     runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
-    needs: version
+    needs: [slim, core, perl]
     steps:
-      - name: Check out the codebase
-        uses: actions/checkout@v4
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
@@ -329,88 +370,6 @@ jobs:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
 
-      - name: Login to Amazon ECR
-        uses: aws-actions/amazon-ecr-login@v2
-        with:
-          registry-type: public
-
-      - name: Login to Docker Hub
-        uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-
-      - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Login to Quay
-        uses: docker/login-action@v3
-        with:
-          registry: quay.io
-          username: ${{ secrets.QUAY_USERNAME }}
-          password: ${{ secrets.QUAY_TOKEN }}
-
-      - name: Extract metadata (tags, labels) for Docker
-        id: meta
-        uses: docker/metadata-action@v5
-        with:
-          images: |
-            public.ecr.aws/nginx/nginx-unprivileged
-            docker.io/nginxinc/nginx-unprivileged
-            ghcr.io/nginxinc/nginx-unprivileged
-            quay.io/nginx/nginx-unprivileged
-          tags: |
-            type=raw,value=${{ needs.version.outputs.major }}.${{ needs.version.outputs.minor }}.${{ needs.version.outputs.patch }}-alpine-slim
-            type=raw,value=${{ needs.version.outputs.major }}.${{ needs.version.outputs.minor }}.${{ needs.version.outputs.patch }}-alpine${{ needs.version.outputs.distro }}-slim
-            type=raw,value=${{ needs.version.outputs.major }}.${{ needs.version.outputs.minor }}-alpine-slim
-            type=raw,value=${{ needs.version.outputs.major }}.${{ needs.version.outputs.minor }}-alpine${{ needs.version.outputs.distro }}-slim
-            type=raw,value=${{ needs.version.outputs.major }}-alpine-slim
-            type=raw,value=${{ needs.version.outputs.major }}-alpine${{ needs.version.outputs.distro }}-slim
-            type=raw,value=mainline-alpine-slim
-            type=raw,value=mainline-alpine${{ needs.version.outputs.distro }}-slim
-            type=raw,value=alpine-slim
-            type=raw,value=alpine${{ needs.version.outputs.distro }}-slim
-
-      - name: Build and push NGINX mainline slim Alpine image to Amazon ECR, Docker Hub and GitHub Container Registry
-        id: build
-        uses: docker/build-push-action@v5
-        with:
-          platforms: linux/amd64, linux/arm/v6, linux/arm/v7, linux/arm64, linux/386, linux/ppc64le, linux/s390x
-          context: "{{ defaultContext }}:mainline/alpine-slim"
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          push: true
-          # cache-from: type=gha,scope=alpine-slim
-          # cache-to: type=gha,mode=min,scope=alpine-slim
-
-      - name: Sign Docker Hub Manifest
+      - name: Delete untagged Alpine NGINX mainline Docker images on the Amazon ECR Public Gallery
         run: |
-          set -ex
-          sudo apt update
-          sudo apt install -y notary
-          mkdir -p ~/.docker/trust/private
-          echo "$DOCKER_CONTENT_TRUST_REPOSITORY_KEY" > ~/.docker/trust/private/$DOCKER_CONTENT_TRUST_REPOSITORY_KEY_ID.key
-          chmod 0400 ~/.docker/trust/private/$DOCKER_CONTENT_TRUST_REPOSITORY_KEY_ID.key
-          docker trust key load ~/.docker/trust/private/$DOCKER_CONTENT_TRUST_REPOSITORY_KEY_ID.key --name nginx
-          DIGEST=$(printf '${{ steps.build.outputs.metadata }}' | jq -r '."containerimage.descriptor".digest' | cut -d ':' -f2)
-          SIZE=$(printf '${{ steps.build.outputs.metadata }}' | jq -r '."containerimage.descriptor".size')
-          export NOTARY_AUTH=$(printf "${{ secrets.DOCKERHUB_USERNAME }}:${{ secrets.DOCKERHUB_TOKEN }}" | base64 -w0)
-          notary -d ~/.docker/trust/ -s https://notary.docker.io addhash docker.io/nginxinc/nginx-unprivileged ${{ needs.version.outputs.major }}.${{ needs.version.outputs.minor }}.${{ needs.version.outputs.patch }}-alpine-slim $SIZE --sha256 $DIGEST --publish --verbose
-          notary -d ~/.docker/trust/ -s https://notary.docker.io addhash docker.io/nginxinc/nginx-unprivileged ${{ needs.version.outputs.major }}.${{ needs.version.outputs.minor }}.${{ needs.version.outputs.patch }}-alpine${{ needs.version.outputs.distro }}-slim $SIZE --sha256 $DIGEST --publish --verbose
-          notary -d ~/.docker/trust/ -s https://notary.docker.io addhash docker.io/nginxinc/nginx-unprivileged ${{ needs.version.outputs.major }}.${{ needs.version.outputs.minor }}-alpine-slim $SIZE --sha256 $DIGEST --publish --verbose
-          notary -d ~/.docker/trust/ -s https://notary.docker.io addhash docker.io/nginxinc/nginx-unprivileged ${{ needs.version.outputs.major }}.${{ needs.version.outputs.minor }}-alpine${{ needs.version.outputs.distro }}-slim $SIZE --sha256 $DIGEST --publish --verbose
-          notary -d ~/.docker/trust/ -s https://notary.docker.io addhash docker.io/nginxinc/nginx-unprivileged ${{ needs.version.outputs.major }}-alpine-slim $SIZE --sha256 $DIGEST --publish --verbose
-          notary -d ~/.docker/trust/ -s https://notary.docker.io addhash docker.io/nginxinc/nginx-unprivileged ${{ needs.version.outputs.major }}-alpine${{ needs.version.outputs.distro }}-slim $SIZE --sha256 $DIGEST --publish --verbose
-          notary -d ~/.docker/trust/ -s https://notary.docker.io addhash docker.io/nginxinc/nginx-unprivileged mainline-alpine-slim $SIZE --sha256 $DIGEST --publish --verbose
-          notary -d ~/.docker/trust/ -s https://notary.docker.io addhash docker.io/nginxinc/nginx-unprivileged mainline-alpine${{ needs.version.outputs.distro }}-slim $SIZE --sha256 $DIGEST --publish --verbose
-          notary -d ~/.docker/trust/ -s https://notary.docker.io addhash docker.io/nginxinc/nginx-unprivileged alpine-slim $SIZE --sha256 $DIGEST --publish --verbose
-          notary -d ~/.docker/trust/ -s https://notary.docker.io addhash docker.io/nginxinc/nginx-unprivileged alpine${{ needs.version.outputs.distro }}-slim $SIZE --sha256 $DIGEST --publish --verbose
-        env:
-          DOCKER_CONTENT_TRUST_REPOSITORY_KEY: ${{ secrets.DOCKER_CONTENT_TRUST_REPOSITORY_KEY }}
-          DOCKER_CONTENT_TRUST_REPOSITORY_KEY_ID: ${{ secrets.DOCKER_CONTENT_TRUST_REPOSITORY_KEY_ID }}
-          DOCKER_CONTENT_TRUST_REPOSITORY_PASSPHRASE: ${{ secrets.DOCKER_CONTENT_TRUST_REPOSITORY_PASSPHRASE }}
-          NOTARY_TARGETS_PASSPHRASE: ${{ secrets.DOCKER_CONTENT_TRUST_REPOSITORY_PASSPHRASE }}
+          .github/workflows/scripts/delete-untagged-amazon-public-ecr-images.sh

--- a/.github/workflows/alpine-mainline.yml
+++ b/.github/workflows/alpine-mainline.yml
@@ -25,10 +25,10 @@ jobs:
           REPOSITORY_NAME=nginx-unprivileged
 
           IMAGE_DIGESTS=$(aws ecr-public describe-images \
-          --max-items 100 \
-          --repository-name $REPOSITORY_NAME \
-          --query 'imageDetails[?!imageTags && (contains(imageManifestMediaType, `manifest.list.v2`) || contains(imageManifestMediaType, `image.index.v1`))].{imageDigest: join(`=`, [`imageDigest`, imageDigest])}' \
-          --output text)
+            --max-items 100 \
+            --repository-name $REPOSITORY_NAME \
+            --query 'imageDetails[?!imageTags && (contains(imageManifestMediaType, `manifest.list.v2`) || contains(imageManifestMediaType, `image.index.v1`))].{imageDigest: join(`=`, [`imageDigest`, imageDigest])}' \
+            | jq -r '.[]' | join(" "))
 
           # IMAGES=$(aws ecr-public describe-images \
           #   --repository-name $REPOSITORY_NAME \

--- a/.github/workflows/alpine-mainline.yml
+++ b/.github/workflows/alpine-mainline.yml
@@ -26,7 +26,7 @@ jobs:
 
           IMAGE_DIGESTS=$(aws ecr-public describe-images \
           --max-items 100 \
-          --repository-name "${REPOSITORY_NAME}" \
+          --repository-name $REPOSITORY_NAME \
           --query 'imageDetails[?!imageTags && (contains(imageManifestMediaType, `manifest.list.v2`) || contains(imageManifestMediaType, `image.index.v1`))].{imageDigest: join(`=`, [`imageDigest`, imageDigest])}' \
           --output text)
 

--- a/.github/workflows/alpine-mainline.yml
+++ b/.github/workflows/alpine-mainline.yml
@@ -46,7 +46,7 @@ jobs:
             --repository-name "${REPOSITORY_NAME}" \
             --query 'imageDetails[?!imageTags].{imageDigest: join(`=`, [`imageDigest`, imageDigest])}' \
             --output text)
-          batch_delete "${IMAGE_DIGESTS}
+          batch_delete "${IMAGE_DIGESTS}"
 
 
         #   REPOSITORY_NAME=nginx-unprivileged

--- a/.github/workflows/alpine-mainline.yml
+++ b/.github/workflows/alpine-mainline.yml
@@ -363,6 +363,9 @@ jobs:
       fail-fast: false
     needs: [slim, core, perl]
     steps:
+      - name: Check out the codebase
+        uses: actions/checkout@v4
+
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:

--- a/.github/workflows/alpine-mainline.yml
+++ b/.github/workflows/alpine-mainline.yml
@@ -23,6 +23,7 @@ jobs:
       - name: Cleanup AWS ECR
         run: |
           REPOSITORY_NAME=nginx-unprivileged
+          BATCH_DELETE_SIZE=100
           function batch_delete {
             while read -r batch; do
                 if [ -z "${batch}" ]; then

--- a/.github/workflows/alpine-mainline.yml
+++ b/.github/workflows/alpine-mainline.yml
@@ -34,8 +34,7 @@ jobs:
 
           aws ecr-public batch-delete-image \
             --repository-name $REPOSITORY_NAME \
-            --image-ids $IMAGE_DIGESTS \
-            --dry-run
+            --image-ids $IMAGE_DIGESTS
         # env:
         #   aws-region: ${{ secrets.AWS_REGION }}
         #   aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}

--- a/.github/workflows/alpine-mainline.yml
+++ b/.github/workflows/alpine-mainline.yml
@@ -24,13 +24,19 @@ jobs:
         run: |
           REPOSITORY_NAME=nginx-unprivileged
 
-          IMAGES=$(aws ecr-public describe-images \
-            --repository-name $REPOSITORY_NAME \
-            --region us-east-1 --max-items 100 | jq -r .imageDetails)
+          IMAGE_DIGESTS=$(aws ecr-public describe-images \
+          --max-items 100 \
+          --repository-name "${REPOSITORY_NAME}" \
+          --query 'imageDetails[?!imageTags && (contains(imageManifestMediaType, `manifest.list.v2`) || contains(imageManifestMediaType, `image.index.v1`))].{imageDigest: join(`=`, [`imageDigest`, imageDigest])}' \
+          --output text)
 
-          UNTAGGED_IMAGES=$(jq -r 'map(select(has("imageTags") | not))' <<< $IMAGES)
+          # IMAGES=$(aws ecr-public describe-images \
+          #   --repository-name $REPOSITORY_NAME \
+          #   --region us-east-1 --max-items 100 | jq -r .imageDetails)
 
-          IMAGE_DIGESTS=$(jq -r '[.[] | "imageDigest=\(.imageDigest)"] | join(" ")' <<< $UNTAGGED_IMAGES)
+          # UNTAGGED_IMAGES=$(jq -r 'map(select(has("imageTags") | not))' <<< $IMAGES)
+
+          # IMAGE_DIGESTS=$(jq -r '[.[] | "imageDigest=\(.imageDigest)"] | join(" ")' <<< $UNTAGGED_IMAGES)
 
           aws ecr-public batch-delete-image \
             --repository-name $REPOSITORY_NAME \

--- a/.github/workflows/alpine-mainline.yml
+++ b/.github/workflows/alpine-mainline.yml
@@ -23,25 +23,51 @@ jobs:
       - name: Cleanup AWS ECR
         run: |
           REPOSITORY_NAME=nginx-unprivileged
+          function batch_delete {
+            while read -r batch; do
+                if [ -z "${batch}" ]; then
+                    break
+                fi
 
+                echo "Deleting ${batch}"
+                aws ecr-public batch-delete-image \
+                    --repository-name "${REPOSITORY_NAME}" \
+                    --image-ids ${batch}
+
+            done < <(xargs -L ${BATCH_DELETE_SIZE} <<<"$1")
+          }
           IMAGE_DIGESTS=$(aws ecr-public describe-images \
-            --max-items 100 \
-            --repository-name $REPOSITORY_NAME \
+            --repository-name "${REPOSITORY_NAME}" \
             --query 'imageDetails[?!imageTags && (contains(imageManifestMediaType, `manifest.list.v2`) || contains(imageManifestMediaType, `image.index.v1`))].{imageDigest: join(`=`, [`imageDigest`, imageDigest])}' \
-            | jq -r '.[]' | join(" "))
+            --output text)
+          batch_delete "${IMAGE_DIGESTS}"
+          IMAGE_DIGESTS=$(aws ecr-public describe-images \
+            --repository-name "${REPOSITORY_NAME}" \
+            --query 'imageDetails[?!imageTags].{imageDigest: join(`=`, [`imageDigest`, imageDigest])}' \
+            --output text)
+          batch_delete "${IMAGE_DIGESTS}
 
-          # IMAGES=$(aws ecr-public describe-images \
-          #   --repository-name $REPOSITORY_NAME \
-          #   --region us-east-1 --max-items 100 | jq -r .imageDetails)
 
-          # UNTAGGED_IMAGES=$(jq -r 'map(select(has("imageTags") | not))' <<< $IMAGES)
+        #   REPOSITORY_NAME=nginx-unprivileged
 
-          # IMAGE_DIGESTS=$(jq -r '[.[] | "imageDigest=\(.imageDigest)"] | join(" ")' <<< $UNTAGGED_IMAGES)
+        #   IMAGE_DIGESTS=$(aws ecr-public describe-images \
+        #     --max-items 100 \
+        #     --repository-name $REPOSITORY_NAME \
+        #     --query 'imageDetails[?!imageTags && (contains(imageManifestMediaType, `manifest.list.v2`) || contains(imageManifestMediaType, `image.index.v1`))].{imageDigest: join(`=`, [`imageDigest`, imageDigest])}' \
+        #     | jq -r '.[]' | join(" "))
 
-          aws ecr-public batch-delete-image \
-            --repository-name $REPOSITORY_NAME \
-            --image-ids $IMAGE_DIGESTS
-        # env:
+        #   # IMAGES=$(aws ecr-public describe-images \
+        #   #   --repository-name $REPOSITORY_NAME \
+        #   #   --region us-east-1 --max-items 100 | jq -r .imageDetails)
+
+        #   # UNTAGGED_IMAGES=$(jq -r 'map(select(has("imageTags") | not))' <<< $IMAGES)
+
+        #   # IMAGE_DIGESTS=$(jq -r '[.[] | "imageDigest=\(.imageDigest)"] | join(" ")' <<< $UNTAGGED_IMAGES)
+
+        #   aws ecr-public batch-delete-image \
+        #     --repository-name $REPOSITORY_NAME \
+        #     --image-ids $IMAGE_DIGESTS
+        # # env:
         #   aws-region: ${{ secrets.AWS_REGION }}
         #   aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
         #   aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/alpine-mainline.yml
+++ b/.github/workflows/alpine-mainline.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Cleanup AWS ECR
         run: |
           REPOSITORY_NAME=nginx-unprivileged
-          BATCH_DELETE_SIZE=100
+          BATCH_DELETE_SIZE=1000
           function batch_delete {
             while read -r batch; do
                 if [ -z "${batch}" ]; then

--- a/.github/workflows/alpine-mainline.yml
+++ b/.github/workflows/alpine-mainline.yml
@@ -26,7 +26,7 @@ jobs:
 
           IMAGES=$(aws ecr-public describe-images \
             --repository-name $REPOSITORY_NAME \
-            --region us-east-1 | jq -r .imageDetails)
+            --region us-east-1 --max-items 100 | jq -r .imageDetails)
 
           UNTAGGED_IMAGES=$(jq -r 'map(select(has("imageTags") | not))' <<< $IMAGES)
 

--- a/.github/workflows/alpine-stable.yml
+++ b/.github/workflows/alpine-stable.yml
@@ -29,6 +29,107 @@ jobs:
         run: |
           echo "release=$(cat update.sh | grep -m5 '\[stable\]=' | tail -n1 | cut -d"'" -f2)" >> "$GITHUB_OUTPUT"
 
+  slim:
+    name: Build Alpine NGINX stable slim Docker image
+    runs-on: ubuntu-22.04
+    strategy:
+      fail-fast: false
+    needs: version
+    steps:
+      - name: Check out the codebase
+        uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-region: ${{ secrets.AWS_REGION }}
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+
+      - name: Login to Amazon ECR
+        uses: aws-actions/amazon-ecr-login@v2
+        with:
+          registry-type: public
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Login to Quay
+        uses: docker/login-action@v3
+        with:
+          registry: quay.io
+          username: ${{ secrets.QUAY_USERNAME }}
+          password: ${{ secrets.QUAY_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: |
+            public.ecr.aws/nginx/nginx-unprivileged
+            docker.io/nginxinc/nginx-unprivileged
+            ghcr.io/nginxinc/nginx-unprivileged
+            quay.io/nginx/nginx-unprivileged
+          tags: |
+            type=raw,value=${{ needs.version.outputs.major }}.${{ needs.version.outputs.minor }}.${{ needs.version.outputs.patch }}-alpine-slim
+            type=raw,value=${{ needs.version.outputs.major }}.${{ needs.version.outputs.minor }}.${{ needs.version.outputs.patch }}-alpine${{ needs.version.outputs.distro }}-slim
+            type=raw,value=${{ needs.version.outputs.major }}.${{ needs.version.outputs.minor }}-alpine-slim
+            type=raw,value=${{ needs.version.outputs.major }}.${{ needs.version.outputs.minor }}-alpine${{ needs.version.outputs.distro }}-slim
+            type=raw,value=stable-alpine-slim
+            type=raw,value=stable-alpine${{ needs.version.outputs.distro }}-slim
+
+      - name: Build and push NGINX stable slim Alpine image to Amazon ECR, Docker Hub and GitHub Container Registry
+        id: build
+        uses: docker/build-push-action@v5
+        with:
+          platforms: linux/amd64, linux/arm/v6, linux/arm/v7, linux/arm64, linux/386, linux/ppc64le, linux/s390x
+          context: "{{ defaultContext }}:stable/alpine-slim"
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          push: true
+          # cache-from: type=gha,scope=stable-alpine-slim
+          # cache-to: type=gha,mode=min,scope=stable-alpine-slim
+
+      - name: Sign Docker Hub Manifest
+        run: |
+          set -ex
+          sudo apt update
+          sudo apt install -y notary
+          mkdir -p ~/.docker/trust/private
+          echo "$DOCKER_CONTENT_TRUST_REPOSITORY_KEY" > ~/.docker/trust/private/$DOCKER_CONTENT_TRUST_REPOSITORY_KEY_ID.key
+          chmod 0400 ~/.docker/trust/private/$DOCKER_CONTENT_TRUST_REPOSITORY_KEY_ID.key
+          docker trust key load ~/.docker/trust/private/$DOCKER_CONTENT_TRUST_REPOSITORY_KEY_ID.key --name nginx
+          DIGEST=$(printf '${{ steps.build.outputs.metadata }}' | jq -r '."containerimage.descriptor".digest' | cut -d ':' -f2)
+          SIZE=$(printf '${{ steps.build.outputs.metadata }}' | jq -r '."containerimage.descriptor".size')
+          export NOTARY_AUTH=$(printf "${{ secrets.DOCKERHUB_USERNAME }}:${{ secrets.DOCKERHUB_TOKEN }}" | base64 -w0)
+          notary -d ~/.docker/trust/ -s https://notary.docker.io addhash docker.io/nginxinc/nginx-unprivileged ${{ needs.version.outputs.major }}.${{ needs.version.outputs.minor }}.${{ needs.version.outputs.patch }}-alpine-slim $SIZE --sha256 $DIGEST --publish --verbose
+          notary -d ~/.docker/trust/ -s https://notary.docker.io addhash docker.io/nginxinc/nginx-unprivileged ${{ needs.version.outputs.major }}.${{ needs.version.outputs.minor }}.${{ needs.version.outputs.patch }}-alpine${{ needs.version.outputs.distro }}-slim $SIZE --sha256 $DIGEST --publish --verbose
+          notary -d ~/.docker/trust/ -s https://notary.docker.io addhash docker.io/nginxinc/nginx-unprivileged ${{ needs.version.outputs.major }}.${{ needs.version.outputs.minor }}-alpine-slim $SIZE --sha256 $DIGEST --publish --verbose
+          notary -d ~/.docker/trust/ -s https://notary.docker.io addhash docker.io/nginxinc/nginx-unprivileged ${{ needs.version.outputs.major }}.${{ needs.version.outputs.minor }}-alpine${{ needs.version.outputs.distro }}-slim $SIZE --sha256 $DIGEST --publish --verbose
+          notary -d ~/.docker/trust/ -s https://notary.docker.io addhash docker.io/nginxinc/nginx-unprivileged stable-alpine-slim $SIZE --sha256 $DIGEST --publish --verbose
+          notary -d ~/.docker/trust/ -s https://notary.docker.io addhash docker.io/nginxinc/nginx-unprivileged stable-alpine${{ needs.version.outputs.distro }}-slim $SIZE --sha256 $DIGEST --publish --verbose
+        env:
+          DOCKER_CONTENT_TRUST_REPOSITORY_KEY: ${{ secrets.DOCKER_CONTENT_TRUST_REPOSITORY_KEY }}
+          DOCKER_CONTENT_TRUST_REPOSITORY_KEY_ID: ${{ secrets.DOCKER_CONTENT_TRUST_REPOSITORY_KEY_ID }}
+          DOCKER_CONTENT_TRUST_REPOSITORY_PASSPHRASE: ${{ secrets.DOCKER_CONTENT_TRUST_REPOSITORY_PASSPHRASE }}
+          NOTARY_TARGETS_PASSPHRASE: ${{ secrets.DOCKER_CONTENT_TRUST_REPOSITORY_PASSPHRASE }}
+
   core:
     name: Build Alpine NGINX stable Docker image
     runs-on: ubuntu-22.04
@@ -231,22 +332,13 @@ jobs:
           DOCKER_CONTENT_TRUST_REPOSITORY_PASSPHRASE: ${{ secrets.DOCKER_CONTENT_TRUST_REPOSITORY_PASSPHRASE }}
           NOTARY_TARGETS_PASSPHRASE: ${{ secrets.DOCKER_CONTENT_TRUST_REPOSITORY_PASSPHRASE }}
 
-  slim:
-    name: Build Alpine NGINX stable slim Docker image
+  cleanup:
+    name: Delete untagged Alpine NGINX stable Docker images on the Amazon ECR Public Gallery
     runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
-    needs: version
+    needs: [slim, core, perl]
     steps:
-      - name: Check out the codebase
-        uses: actions/checkout@v4
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
@@ -254,80 +346,6 @@ jobs:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
 
-      - name: Login to Amazon ECR
-        uses: aws-actions/amazon-ecr-login@v2
-        with:
-          registry-type: public
-
-      - name: Login to Docker Hub
-        uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-
-      - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Login to Quay
-        uses: docker/login-action@v3
-        with:
-          registry: quay.io
-          username: ${{ secrets.QUAY_USERNAME }}
-          password: ${{ secrets.QUAY_TOKEN }}
-
-      - name: Extract metadata (tags, labels) for Docker
-        id: meta
-        uses: docker/metadata-action@v5
-        with:
-          images: |
-            public.ecr.aws/nginx/nginx-unprivileged
-            docker.io/nginxinc/nginx-unprivileged
-            ghcr.io/nginxinc/nginx-unprivileged
-            quay.io/nginx/nginx-unprivileged
-          tags: |
-            type=raw,value=${{ needs.version.outputs.major }}.${{ needs.version.outputs.minor }}.${{ needs.version.outputs.patch }}-alpine-slim
-            type=raw,value=${{ needs.version.outputs.major }}.${{ needs.version.outputs.minor }}.${{ needs.version.outputs.patch }}-alpine${{ needs.version.outputs.distro }}-slim
-            type=raw,value=${{ needs.version.outputs.major }}.${{ needs.version.outputs.minor }}-alpine-slim
-            type=raw,value=${{ needs.version.outputs.major }}.${{ needs.version.outputs.minor }}-alpine${{ needs.version.outputs.distro }}-slim
-            type=raw,value=stable-alpine-slim
-            type=raw,value=stable-alpine${{ needs.version.outputs.distro }}-slim
-
-      - name: Build and push NGINX stable slim Alpine image to Amazon ECR, Docker Hub and GitHub Container Registry
-        id: build
-        uses: docker/build-push-action@v5
-        with:
-          platforms: linux/amd64, linux/arm/v6, linux/arm/v7, linux/arm64, linux/386, linux/ppc64le, linux/s390x
-          context: "{{ defaultContext }}:stable/alpine-slim"
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          push: true
-          # cache-from: type=gha,scope=stable-alpine-slim
-          # cache-to: type=gha,mode=min,scope=stable-alpine-slim
-
-      - name: Sign Docker Hub Manifest
+      - name: Delete untagged Alpine NGINX stable Docker images on the Amazon ECR Public Gallery
         run: |
-          set -ex
-          sudo apt update
-          sudo apt install -y notary
-          mkdir -p ~/.docker/trust/private
-          echo "$DOCKER_CONTENT_TRUST_REPOSITORY_KEY" > ~/.docker/trust/private/$DOCKER_CONTENT_TRUST_REPOSITORY_KEY_ID.key
-          chmod 0400 ~/.docker/trust/private/$DOCKER_CONTENT_TRUST_REPOSITORY_KEY_ID.key
-          docker trust key load ~/.docker/trust/private/$DOCKER_CONTENT_TRUST_REPOSITORY_KEY_ID.key --name nginx
-          DIGEST=$(printf '${{ steps.build.outputs.metadata }}' | jq -r '."containerimage.descriptor".digest' | cut -d ':' -f2)
-          SIZE=$(printf '${{ steps.build.outputs.metadata }}' | jq -r '."containerimage.descriptor".size')
-          export NOTARY_AUTH=$(printf "${{ secrets.DOCKERHUB_USERNAME }}:${{ secrets.DOCKERHUB_TOKEN }}" | base64 -w0)
-          notary -d ~/.docker/trust/ -s https://notary.docker.io addhash docker.io/nginxinc/nginx-unprivileged ${{ needs.version.outputs.major }}.${{ needs.version.outputs.minor }}.${{ needs.version.outputs.patch }}-alpine-slim $SIZE --sha256 $DIGEST --publish --verbose
-          notary -d ~/.docker/trust/ -s https://notary.docker.io addhash docker.io/nginxinc/nginx-unprivileged ${{ needs.version.outputs.major }}.${{ needs.version.outputs.minor }}.${{ needs.version.outputs.patch }}-alpine${{ needs.version.outputs.distro }}-slim $SIZE --sha256 $DIGEST --publish --verbose
-          notary -d ~/.docker/trust/ -s https://notary.docker.io addhash docker.io/nginxinc/nginx-unprivileged ${{ needs.version.outputs.major }}.${{ needs.version.outputs.minor }}-alpine-slim $SIZE --sha256 $DIGEST --publish --verbose
-          notary -d ~/.docker/trust/ -s https://notary.docker.io addhash docker.io/nginxinc/nginx-unprivileged ${{ needs.version.outputs.major }}.${{ needs.version.outputs.minor }}-alpine${{ needs.version.outputs.distro }}-slim $SIZE --sha256 $DIGEST --publish --verbose
-          notary -d ~/.docker/trust/ -s https://notary.docker.io addhash docker.io/nginxinc/nginx-unprivileged stable-alpine-slim $SIZE --sha256 $DIGEST --publish --verbose
-          notary -d ~/.docker/trust/ -s https://notary.docker.io addhash docker.io/nginxinc/nginx-unprivileged stable-alpine${{ needs.version.outputs.distro }}-slim $SIZE --sha256 $DIGEST --publish --verbose
-        env:
-          DOCKER_CONTENT_TRUST_REPOSITORY_KEY: ${{ secrets.DOCKER_CONTENT_TRUST_REPOSITORY_KEY }}
-          DOCKER_CONTENT_TRUST_REPOSITORY_KEY_ID: ${{ secrets.DOCKER_CONTENT_TRUST_REPOSITORY_KEY_ID }}
-          DOCKER_CONTENT_TRUST_REPOSITORY_PASSPHRASE: ${{ secrets.DOCKER_CONTENT_TRUST_REPOSITORY_PASSPHRASE }}
-          NOTARY_TARGETS_PASSPHRASE: ${{ secrets.DOCKER_CONTENT_TRUST_REPOSITORY_PASSPHRASE }}
+          .github/workflows/scripts/delete-untagged-amazon-public-ecr-images.sh

--- a/.github/workflows/alpine-stable.yml
+++ b/.github/workflows/alpine-stable.yml
@@ -348,4 +348,4 @@ jobs:
 
       - name: Delete untagged Alpine NGINX stable Docker images on the Amazon ECR Public Gallery
         run: |
-          ./scripts/delete-untagged-amazon-public-ecr-images.sh
+          .github/workflows/scripts/delete-untagged-amazon-public-ecr-images.sh

--- a/.github/workflows/alpine-stable.yml
+++ b/.github/workflows/alpine-stable.yml
@@ -339,6 +339,9 @@ jobs:
       fail-fast: false
     needs: [slim, core, perl]
     steps:
+      - name: Check out the codebase
+        uses: actions/checkout@v4
+
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:

--- a/.github/workflows/alpine-stable.yml
+++ b/.github/workflows/alpine-stable.yml
@@ -348,4 +348,4 @@ jobs:
 
       - name: Delete untagged Alpine NGINX stable Docker images on the Amazon ECR Public Gallery
         run: |
-          .github/workflows/scripts/delete-untagged-amazon-public-ecr-images.sh
+          ./scripts/delete-untagged-amazon-public-ecr-images.sh

--- a/.github/workflows/debian-mainline.yml
+++ b/.github/workflows/debian-mainline.yml
@@ -254,6 +254,9 @@ jobs:
       fail-fast: false
     needs: [core, perl]
     steps:
+      - name: Check out the codebase
+        uses: actions/checkout@v4
+
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:

--- a/.github/workflows/debian-mainline.yml
+++ b/.github/workflows/debian-mainline.yml
@@ -263,4 +263,4 @@ jobs:
 
       - name: Delete untagged Debian NGINX mainline Docker images on the Amazon ECR Public Gallery
         run: |
-          ./scripts/delete-untagged-amazon-public-ecr-images.sh
+          .github/workflows/scripts/delete-untagged-amazon-public-ecr-images.sh

--- a/.github/workflows/debian-mainline.yml
+++ b/.github/workflows/debian-mainline.yml
@@ -263,4 +263,4 @@ jobs:
 
       - name: Delete untagged Debian NGINX mainline Docker images on the Amazon ECR Public Gallery
         run: |
-          .github/workflows/scripts/delete-untagged-amazon-public-ecr-images.sh
+          ./scripts/delete-untagged-amazon-public-ecr-images.sh

--- a/.github/workflows/debian-mainline.yml
+++ b/.github/workflows/debian-mainline.yml
@@ -246,3 +246,21 @@ jobs:
           DOCKER_CONTENT_TRUST_REPOSITORY_KEY_ID: ${{ secrets.DOCKER_CONTENT_TRUST_REPOSITORY_KEY_ID }}
           DOCKER_CONTENT_TRUST_REPOSITORY_PASSPHRASE: ${{ secrets.DOCKER_CONTENT_TRUST_REPOSITORY_PASSPHRASE }}
           NOTARY_TARGETS_PASSPHRASE: ${{ secrets.DOCKER_CONTENT_TRUST_REPOSITORY_PASSPHRASE }}
+
+  cleanup:
+    name: Delete untagged Debian NGINX mainline Docker images on the Amazon ECR Public Gallery
+    runs-on: ubuntu-22.04
+    strategy:
+      fail-fast: false
+    needs: [core, perl]
+    steps:
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-region: ${{ secrets.AWS_REGION }}
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+
+      - name: Delete untagged Debian NGINX mainline Docker images on the Amazon ECR Public Gallery
+        run: |
+          .github/workflows/scripts/delete-untagged-amazon-public-ecr-images.sh

--- a/.github/workflows/debian-stable.yml
+++ b/.github/workflows/debian-stable.yml
@@ -238,6 +238,9 @@ jobs:
       fail-fast: false
     needs: [core, perl]
     steps:
+      - name: Check out the codebase
+        uses: actions/checkout@v4
+
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:

--- a/.github/workflows/debian-stable.yml
+++ b/.github/workflows/debian-stable.yml
@@ -247,4 +247,4 @@ jobs:
 
       - name: Delete untagged Debian NGINX stable Docker images on the Amazon ECR Public Gallery
         run: |
-          .github/workflows/scripts/delete-untagged-amazon-public-ecr-images.sh
+          ./scripts/delete-untagged-amazon-public-ecr-images.sh

--- a/.github/workflows/debian-stable.yml
+++ b/.github/workflows/debian-stable.yml
@@ -247,4 +247,4 @@ jobs:
 
       - name: Delete untagged Debian NGINX stable Docker images on the Amazon ECR Public Gallery
         run: |
-          ./scripts/delete-untagged-amazon-public-ecr-images.sh
+          .github/workflows/scripts/delete-untagged-amazon-public-ecr-images.sh

--- a/.github/workflows/debian-stable.yml
+++ b/.github/workflows/debian-stable.yml
@@ -230,3 +230,21 @@ jobs:
           DOCKER_CONTENT_TRUST_REPOSITORY_KEY_ID: ${{ secrets.DOCKER_CONTENT_TRUST_REPOSITORY_KEY_ID }}
           DOCKER_CONTENT_TRUST_REPOSITORY_PASSPHRASE: ${{ secrets.DOCKER_CONTENT_TRUST_REPOSITORY_PASSPHRASE }}
           NOTARY_TARGETS_PASSPHRASE: ${{ secrets.DOCKER_CONTENT_TRUST_REPOSITORY_PASSPHRASE }}
+
+  cleanup:
+    name: Delete untagged Debian NGINX stable Docker images on the Amazon ECR Public Gallery
+    runs-on: ubuntu-22.04
+    strategy:
+      fail-fast: false
+    needs: [core, perl]
+    steps:
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-region: ${{ secrets.AWS_REGION }}
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+
+      - name: Delete untagged Debian NGINX stable Docker images on the Amazon ECR Public Gallery
+        run: |
+          .github/workflows/scripts/delete-untagged-amazon-public-ecr-images.sh

--- a/.github/workflows/scripts/delete-untagged-amazon-public-ecr-images.sh
+++ b/.github/workflows/scripts/delete-untagged-amazon-public-ecr-images.sh
@@ -5,7 +5,7 @@
 set -exu
 
 REPOSITORY_NAME=nginx-unprivileged
-BATCH_DELETE_SIZE=100
+BATCH_DELETE_SIZE=100 # The max delete size allowed by the 'batch-delete-image' aws CLI command is 100
 
 function batch_delete {
   while read -r batch; do
@@ -19,6 +19,8 @@ function batch_delete {
   done < <(xargs -L ${BATCH_DELETE_SIZE} <<<"$1")
 }
 
+# Find untagged manifest lists and delete them first as
+# otherwise any referenced untagged images can not be deleted.
 IMAGE_DIGESTS=$(aws ecr-public describe-images \
   --repository-name "${REPOSITORY_NAME}" \
   --query 'imageDetails[?!imageTags && (contains(imageManifestMediaType, `manifest.list.v2`) || contains(imageManifestMediaType, `image.index.v1`))].{imageDigest: join(`=`, [`imageDigest`, imageDigest])}' \
@@ -26,6 +28,7 @@ IMAGE_DIGESTS=$(aws ecr-public describe-images \
 
 batch_delete "${IMAGE_DIGESTS}"
 
+# Find untagged images and delete them.
 IMAGE_DIGESTS=$(aws ecr-public describe-images \
   --repository-name "${REPOSITORY_NAME}" \
   --query 'imageDetails[?!imageTags].{imageDigest: join(`=`, [`imageDigest`, imageDigest])}' \

--- a/.github/workflows/scripts/delete-untagged-amazon-public-ecr-images.sh
+++ b/.github/workflows/scripts/delete-untagged-amazon-public-ecr-images.sh
@@ -2,7 +2,7 @@
 # vim:sw=2:ts=2:sts=2:et
 # Inspired by https://github.com/zeek/zeek/blob/master/ci/public-ecr-cleanup.sh
 
-set -exu
+set -eu
 
 REPOSITORY_NAME=nginx-unprivileged
 BATCH_DELETE_SIZE=100 # The max delete size allowed by the 'batch-delete-image' aws CLI command is 100

--- a/.github/workflows/scripts/delete-untagged-amazon-public-ecr-images.sh
+++ b/.github/workflows/scripts/delete-untagged-amazon-public-ecr-images.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+# vim:sw=2:ts=2:sts=2:et
+# Inspired by https://github.com/zeek/zeek/blob/master/ci/public-ecr-cleanup.sh
+
+set -exu
+
+REPOSITORY_NAME=nginx-unprivileged
+BATCH_DELETE_SIZE=100
+
+function batch_delete {
+  while read -r batch; do
+    if [ -z "${batch}" ]; then
+      break
+    fi
+
+  echo "Deleting ${batch}"
+  aws ecr-public batch-delete-image --repository-name "${REPOSITORY_NAME}" --image-ids ${batch}
+
+  done < <(xargs -L ${BATCH_DELETE_SIZE} <<<"$1")
+}
+
+IMAGE_DIGESTS=$(aws ecr-public describe-images \
+  --repository-name "${REPOSITORY_NAME}" \
+  --query 'imageDetails[?!imageTags && (contains(imageManifestMediaType, `manifest.list.v2`) || contains(imageManifestMediaType, `image.index.v1`))].{imageDigest: join(`=`, [`imageDigest`, imageDigest])}' \
+  --output text)
+
+batch_delete "${IMAGE_DIGESTS}"
+
+IMAGE_DIGESTS=$(aws ecr-public describe-images \
+  --repository-name "${REPOSITORY_NAME}" \
+  --query 'imageDetails[?!imageTags].{imageDigest: join(`=`, [`imageDigest`, imageDigest])}' \
+  --output text)
+
+batch_delete "${IMAGE_DIGESTS}"
+


### PR DESCRIPTION
### Proposed changes

Amazon Public ECR does not automatically cleanup untagged images, which means that over time it's very easy to accumulate a non-trivial amount of images that are fundamentally useless. Since ECR Public also happens to not support life-cycle policies (https://github.com/aws/containers-roadmap/issues/1268), the only automated way to delete untagged images involves using the CLI in an automated script. This PR adds such a script (based on https://github.com/zeek/zeek/blob/master/ci/public-ecr-cleanup.sh, with a few minor tweaks) and incorporates it to the GitHub actions CD pipeline.

### Checklist

Before creating a PR, run through this checklist and mark each as complete:

- [x] I have read the [`CONTRIBUTING`](https://github.com/nginxinc/docker-nginx-unprivileged/blob/main/CONTRIBUTING.md) document
- [x] I have run `./update.sh` and ensured all entrypoint/Dockerfile template changes have been applied to the relevant image entrypoint scripts & Dockerfiles
- [x] I have tested that the NGINX Unprivileged Docker images build and run correctly on all supported architectures on an unprivileged environment (check out the [`README`](https://github.com/nginxinc/docker-nginx-unprivileged/blob/main/README.md) for more details)
- [x] I have updated any relevant documentation ([`README`](https://github.com/nginxinc/docker-nginx-unprivileged/blob/main/README.md))
