### PR TITLE
Add IPv6 support for local-resolvers substitution script

### DIFF
--- a/entrypoint/10-listen-on-ipv6-by-default.sh
+++ b/entrypoint/10-listen-on-ipv6-by-default.sh
@@ -9,7 +9,7 @@ entrypoint_log() {
     fi
 }
 
-ME=$(basename $0)
+ME=$(basename "$0")
 DEFAULT_CONF_FILE="etc/nginx/conf.d/default.conf"
 
 # check if we have ipv6 available

--- a/entrypoint/15-local-resolvers.envsh
+++ b/entrypoint/15-local-resolvers.envsh
@@ -8,4 +8,5 @@ PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 
 [ "${NGINX_ENTRYPOINT_LOCAL_RESOLVERS:-}" ] || return 0
 
-export NGINX_LOCAL_RESOLVERS=$(awk 'BEGIN{ORS=" "} $1=="nameserver" {print $2}' /etc/resolv.conf)
+NGINX_LOCAL_RESOLVERS=$(awk 'BEGIN{ORS=" "} $1=="nameserver" {if ($2 ~ ":") {print "["$2"]"} else {print $2}}' /etc/resolv.conf)
+export NGINX_LOCAL_RESOLVERS

--- a/entrypoint/20-envsubst-on-templates.sh
+++ b/entrypoint/20-envsubst-on-templates.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-ME=$(basename $0)
+ME=$(basename "$0")
 
 entrypoint_log() {
   if [ -z "${NGINX_ENTRYPOINT_QUIET_LOGS:-}" ]; then
@@ -44,8 +44,8 @@ auto_envsubst() {
     return 0
   fi
   find "$template_dir" -follow -type f -name "*$suffix" -print | while read -r template; do
-    relative_path="${template#$template_dir/}"
-    output_path="$output_dir/${relative_path%$suffix}"
+    relative_path="${template#"$template_dir/"}"
+    output_path="$output_dir/${relative_path%"$suffix"}"
     subdir=$(dirname "$relative_path")
     # create a subdirectory where the template file exists
     mkdir -p "$output_dir/$subdir"
@@ -62,8 +62,8 @@ auto_envsubst() {
     fi
     add_stream_block
     find "$template_dir" -follow -type f -name "*$stream_suffix" -print | while read -r template; do
-      relative_path="${template#$template_dir/}"
-      output_path="$stream_output_dir/${relative_path%$stream_suffix}"
+      relative_path="${template#"$template_dir/"}"
+      output_path="$stream_output_dir/${relative_path%"$stream_suffix"}"
       subdir=$(dirname "$relative_path")
       # create a subdirectory where the template file exists
       mkdir -p "$stream_output_dir/$subdir"

--- a/entrypoint/30-tune-worker-processes.sh
+++ b/entrypoint/30-tune-worker-processes.sh
@@ -4,7 +4,7 @@
 set -eu
 
 LC_ALL=C
-ME=$( basename "$0" )
+ME=$(basename "$0")
 PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 
 [ "${NGINX_ENTRYPOINT_WORKER_PROCESSES_AUTOTUNE:-}" ] || exit 0

--- a/entrypoint/docker-entrypoint.sh
+++ b/entrypoint/docker-entrypoint.sh
@@ -9,7 +9,7 @@ entrypoint_log() {
     fi
 }
 
-if [ "$1" = "nginx" -o "$1" = "nginx-debug" ]; then
+if [ "$1" = "nginx" ] || [ "$1" = "nginx-debug" ]; then
     if /usr/bin/find "/docker-entrypoint.d/" -mindepth 1 -maxdepth 1 -type f -print -quit 2>/dev/null | read v; then
         entrypoint_log "$0: /docker-entrypoint.d/ is not empty, will attempt to perform configuration"
 

--- a/mainline/alpine-slim/10-listen-on-ipv6-by-default.sh
+++ b/mainline/alpine-slim/10-listen-on-ipv6-by-default.sh
@@ -9,7 +9,7 @@ entrypoint_log() {
     fi
 }
 
-ME=$(basename $0)
+ME=$(basename "$0")
 DEFAULT_CONF_FILE="etc/nginx/conf.d/default.conf"
 
 # check if we have ipv6 available

--- a/mainline/alpine-slim/15-local-resolvers.envsh
+++ b/mainline/alpine-slim/15-local-resolvers.envsh
@@ -8,4 +8,5 @@ PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 
 [ "${NGINX_ENTRYPOINT_LOCAL_RESOLVERS:-}" ] || return 0
 
-export NGINX_LOCAL_RESOLVERS=$(awk 'BEGIN{ORS=" "} $1=="nameserver" {print $2}' /etc/resolv.conf)
+NGINX_LOCAL_RESOLVERS=$(awk 'BEGIN{ORS=" "} $1=="nameserver" {if ($2 ~ ":") {print "["$2"]"} else {print $2}}' /etc/resolv.conf)
+export NGINX_LOCAL_RESOLVERS

--- a/mainline/alpine-slim/20-envsubst-on-templates.sh
+++ b/mainline/alpine-slim/20-envsubst-on-templates.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-ME=$(basename $0)
+ME=$(basename "$0")
 
 entrypoint_log() {
   if [ -z "${NGINX_ENTRYPOINT_QUIET_LOGS:-}" ]; then
@@ -44,8 +44,8 @@ auto_envsubst() {
     return 0
   fi
   find "$template_dir" -follow -type f -name "*$suffix" -print | while read -r template; do
-    relative_path="${template#$template_dir/}"
-    output_path="$output_dir/${relative_path%$suffix}"
+    relative_path="${template#"$template_dir/"}"
+    output_path="$output_dir/${relative_path%"$suffix"}"
     subdir=$(dirname "$relative_path")
     # create a subdirectory where the template file exists
     mkdir -p "$output_dir/$subdir"
@@ -62,8 +62,8 @@ auto_envsubst() {
     fi
     add_stream_block
     find "$template_dir" -follow -type f -name "*$stream_suffix" -print | while read -r template; do
-      relative_path="${template#$template_dir/}"
-      output_path="$stream_output_dir/${relative_path%$stream_suffix}"
+      relative_path="${template#"$template_dir/"}"
+      output_path="$stream_output_dir/${relative_path%"$stream_suffix"}"
       subdir=$(dirname "$relative_path")
       # create a subdirectory where the template file exists
       mkdir -p "$stream_output_dir/$subdir"

--- a/mainline/alpine-slim/30-tune-worker-processes.sh
+++ b/mainline/alpine-slim/30-tune-worker-processes.sh
@@ -4,7 +4,7 @@
 set -eu
 
 LC_ALL=C
-ME=$( basename "$0" )
+ME=$(basename "$0")
 PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 
 [ "${NGINX_ENTRYPOINT_WORKER_PROCESSES_AUTOTUNE:-}" ] || exit 0

--- a/mainline/alpine-slim/docker-entrypoint.sh
+++ b/mainline/alpine-slim/docker-entrypoint.sh
@@ -9,7 +9,7 @@ entrypoint_log() {
     fi
 }
 
-if [ "$1" = "nginx" -o "$1" = "nginx-debug" ]; then
+if [ "$1" = "nginx" ] || [ "$1" = "nginx-debug" ]; then
     if /usr/bin/find "/docker-entrypoint.d/" -mindepth 1 -maxdepth 1 -type f -print -quit 2>/dev/null | read v; then
         entrypoint_log "$0: /docker-entrypoint.d/ is not empty, will attempt to perform configuration"
 

--- a/mainline/debian/10-listen-on-ipv6-by-default.sh
+++ b/mainline/debian/10-listen-on-ipv6-by-default.sh
@@ -9,7 +9,7 @@ entrypoint_log() {
     fi
 }
 
-ME=$(basename $0)
+ME=$(basename "$0")
 DEFAULT_CONF_FILE="etc/nginx/conf.d/default.conf"
 
 # check if we have ipv6 available

--- a/mainline/debian/15-local-resolvers.envsh
+++ b/mainline/debian/15-local-resolvers.envsh
@@ -8,4 +8,5 @@ PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 
 [ "${NGINX_ENTRYPOINT_LOCAL_RESOLVERS:-}" ] || return 0
 
-export NGINX_LOCAL_RESOLVERS=$(awk 'BEGIN{ORS=" "} $1=="nameserver" {print $2}' /etc/resolv.conf)
+NGINX_LOCAL_RESOLVERS=$(awk 'BEGIN{ORS=" "} $1=="nameserver" {if ($2 ~ ":") {print "["$2"]"} else {print $2}}' /etc/resolv.conf)
+export NGINX_LOCAL_RESOLVERS

--- a/mainline/debian/20-envsubst-on-templates.sh
+++ b/mainline/debian/20-envsubst-on-templates.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-ME=$(basename $0)
+ME=$(basename "$0")
 
 entrypoint_log() {
   if [ -z "${NGINX_ENTRYPOINT_QUIET_LOGS:-}" ]; then
@@ -44,8 +44,8 @@ auto_envsubst() {
     return 0
   fi
   find "$template_dir" -follow -type f -name "*$suffix" -print | while read -r template; do
-    relative_path="${template#$template_dir/}"
-    output_path="$output_dir/${relative_path%$suffix}"
+    relative_path="${template#"$template_dir/"}"
+    output_path="$output_dir/${relative_path%"$suffix"}"
     subdir=$(dirname "$relative_path")
     # create a subdirectory where the template file exists
     mkdir -p "$output_dir/$subdir"
@@ -62,8 +62,8 @@ auto_envsubst() {
     fi
     add_stream_block
     find "$template_dir" -follow -type f -name "*$stream_suffix" -print | while read -r template; do
-      relative_path="${template#$template_dir/}"
-      output_path="$stream_output_dir/${relative_path%$stream_suffix}"
+      relative_path="${template#"$template_dir/"}"
+      output_path="$stream_output_dir/${relative_path%"$stream_suffix"}"
       subdir=$(dirname "$relative_path")
       # create a subdirectory where the template file exists
       mkdir -p "$stream_output_dir/$subdir"

--- a/mainline/debian/30-tune-worker-processes.sh
+++ b/mainline/debian/30-tune-worker-processes.sh
@@ -4,7 +4,7 @@
 set -eu
 
 LC_ALL=C
-ME=$( basename "$0" )
+ME=$(basename "$0")
 PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 
 [ "${NGINX_ENTRYPOINT_WORKER_PROCESSES_AUTOTUNE:-}" ] || exit 0

--- a/mainline/debian/docker-entrypoint.sh
+++ b/mainline/debian/docker-entrypoint.sh
@@ -9,7 +9,7 @@ entrypoint_log() {
     fi
 }
 
-if [ "$1" = "nginx" -o "$1" = "nginx-debug" ]; then
+if [ "$1" = "nginx" ] || [ "$1" = "nginx-debug" ]; then
     if /usr/bin/find "/docker-entrypoint.d/" -mindepth 1 -maxdepth 1 -type f -print -quit 2>/dev/null | read v; then
         entrypoint_log "$0: /docker-entrypoint.d/ is not empty, will attempt to perform configuration"
 

--- a/stable/alpine-slim/10-listen-on-ipv6-by-default.sh
+++ b/stable/alpine-slim/10-listen-on-ipv6-by-default.sh
@@ -9,7 +9,7 @@ entrypoint_log() {
     fi
 }
 
-ME=$(basename $0)
+ME=$(basename "$0")
 DEFAULT_CONF_FILE="etc/nginx/conf.d/default.conf"
 
 # check if we have ipv6 available

--- a/stable/alpine-slim/15-local-resolvers.envsh
+++ b/stable/alpine-slim/15-local-resolvers.envsh
@@ -8,4 +8,5 @@ PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 
 [ "${NGINX_ENTRYPOINT_LOCAL_RESOLVERS:-}" ] || return 0
 
-export NGINX_LOCAL_RESOLVERS=$(awk 'BEGIN{ORS=" "} $1=="nameserver" {print $2}' /etc/resolv.conf)
+NGINX_LOCAL_RESOLVERS=$(awk 'BEGIN{ORS=" "} $1=="nameserver" {if ($2 ~ ":") {print "["$2"]"} else {print $2}}' /etc/resolv.conf)
+export NGINX_LOCAL_RESOLVERS

--- a/stable/alpine-slim/20-envsubst-on-templates.sh
+++ b/stable/alpine-slim/20-envsubst-on-templates.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-ME=$(basename $0)
+ME=$(basename "$0")
 
 entrypoint_log() {
   if [ -z "${NGINX_ENTRYPOINT_QUIET_LOGS:-}" ]; then
@@ -44,8 +44,8 @@ auto_envsubst() {
     return 0
   fi
   find "$template_dir" -follow -type f -name "*$suffix" -print | while read -r template; do
-    relative_path="${template#$template_dir/}"
-    output_path="$output_dir/${relative_path%$suffix}"
+    relative_path="${template#"$template_dir/"}"
+    output_path="$output_dir/${relative_path%"$suffix"}"
     subdir=$(dirname "$relative_path")
     # create a subdirectory where the template file exists
     mkdir -p "$output_dir/$subdir"
@@ -62,8 +62,8 @@ auto_envsubst() {
     fi
     add_stream_block
     find "$template_dir" -follow -type f -name "*$stream_suffix" -print | while read -r template; do
-      relative_path="${template#$template_dir/}"
-      output_path="$stream_output_dir/${relative_path%$stream_suffix}"
+      relative_path="${template#"$template_dir/"}"
+      output_path="$stream_output_dir/${relative_path%"$stream_suffix"}"
       subdir=$(dirname "$relative_path")
       # create a subdirectory where the template file exists
       mkdir -p "$stream_output_dir/$subdir"

--- a/stable/alpine-slim/30-tune-worker-processes.sh
+++ b/stable/alpine-slim/30-tune-worker-processes.sh
@@ -4,7 +4,7 @@
 set -eu
 
 LC_ALL=C
-ME=$( basename "$0" )
+ME=$(basename "$0")
 PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 
 [ "${NGINX_ENTRYPOINT_WORKER_PROCESSES_AUTOTUNE:-}" ] || exit 0

--- a/stable/alpine-slim/docker-entrypoint.sh
+++ b/stable/alpine-slim/docker-entrypoint.sh
@@ -9,7 +9,7 @@ entrypoint_log() {
     fi
 }
 
-if [ "$1" = "nginx" -o "$1" = "nginx-debug" ]; then
+if [ "$1" = "nginx" ] || [ "$1" = "nginx-debug" ]; then
     if /usr/bin/find "/docker-entrypoint.d/" -mindepth 1 -maxdepth 1 -type f -print -quit 2>/dev/null | read v; then
         entrypoint_log "$0: /docker-entrypoint.d/ is not empty, will attempt to perform configuration"
 

--- a/stable/debian/10-listen-on-ipv6-by-default.sh
+++ b/stable/debian/10-listen-on-ipv6-by-default.sh
@@ -9,7 +9,7 @@ entrypoint_log() {
     fi
 }
 
-ME=$(basename $0)
+ME=$(basename "$0")
 DEFAULT_CONF_FILE="etc/nginx/conf.d/default.conf"
 
 # check if we have ipv6 available

--- a/stable/debian/15-local-resolvers.envsh
+++ b/stable/debian/15-local-resolvers.envsh
@@ -8,4 +8,5 @@ PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 
 [ "${NGINX_ENTRYPOINT_LOCAL_RESOLVERS:-}" ] || return 0
 
-export NGINX_LOCAL_RESOLVERS=$(awk 'BEGIN{ORS=" "} $1=="nameserver" {print $2}' /etc/resolv.conf)
+NGINX_LOCAL_RESOLVERS=$(awk 'BEGIN{ORS=" "} $1=="nameserver" {if ($2 ~ ":") {print "["$2"]"} else {print $2}}' /etc/resolv.conf)
+export NGINX_LOCAL_RESOLVERS

--- a/stable/debian/20-envsubst-on-templates.sh
+++ b/stable/debian/20-envsubst-on-templates.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-ME=$(basename $0)
+ME=$(basename "$0")
 
 entrypoint_log() {
   if [ -z "${NGINX_ENTRYPOINT_QUIET_LOGS:-}" ]; then
@@ -44,8 +44,8 @@ auto_envsubst() {
     return 0
   fi
   find "$template_dir" -follow -type f -name "*$suffix" -print | while read -r template; do
-    relative_path="${template#$template_dir/}"
-    output_path="$output_dir/${relative_path%$suffix}"
+    relative_path="${template#"$template_dir/"}"
+    output_path="$output_dir/${relative_path%"$suffix"}"
     subdir=$(dirname "$relative_path")
     # create a subdirectory where the template file exists
     mkdir -p "$output_dir/$subdir"
@@ -62,8 +62,8 @@ auto_envsubst() {
     fi
     add_stream_block
     find "$template_dir" -follow -type f -name "*$stream_suffix" -print | while read -r template; do
-      relative_path="${template#$template_dir/}"
-      output_path="$stream_output_dir/${relative_path%$stream_suffix}"
+      relative_path="${template#"$template_dir/"}"
+      output_path="$stream_output_dir/${relative_path%"$stream_suffix"}"
       subdir=$(dirname "$relative_path")
       # create a subdirectory where the template file exists
       mkdir -p "$stream_output_dir/$subdir"

--- a/stable/debian/30-tune-worker-processes.sh
+++ b/stable/debian/30-tune-worker-processes.sh
@@ -4,7 +4,7 @@
 set -eu
 
 LC_ALL=C
-ME=$( basename "$0" )
+ME=$(basename "$0")
 PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 
 [ "${NGINX_ENTRYPOINT_WORKER_PROCESSES_AUTOTUNE:-}" ] || exit 0

--- a/stable/debian/docker-entrypoint.sh
+++ b/stable/debian/docker-entrypoint.sh
@@ -9,7 +9,7 @@ entrypoint_log() {
     fi
 }
 
-if [ "$1" = "nginx" -o "$1" = "nginx-debug" ]; then
+if [ "$1" = "nginx" ] || [ "$1" = "nginx-debug" ]; then
     if /usr/bin/find "/docker-entrypoint.d/" -mindepth 1 -maxdepth 1 -type f -print -quit 2>/dev/null | read v; then
         entrypoint_log "$0: /docker-entrypoint.d/ is not empty, will attempt to perform configuration"
 


### PR DESCRIPTION
### Proposed changes

This PR ports the latest updates made to the upstream https://github.com/nginxinc/docker-nginx image. It adds IPv6 support for local-resolvers substitution script, addresses an Alpine bug, and fixes some shell linter warnings.

### Checklist

Before creating a PR, run through this checklist and mark each as complete:

- [x] I have read the [`CONTRIBUTING`](https://github.com/nginxinc/docker-nginx-unprivileged/blob/main/CONTRIBUTING.md) document
- [x] I have run `./update.sh` and ensured all entrypoint/Dockerfile template changes have been applied to the relevant image entrypoint scripts & Dockerfiles
- [x] I have tested that the NGINX Unprivileged Docker images build and run correctly on all supported architectures on an unprivileged environment (check out the [`README`](https://github.com/nginxinc/docker-nginx-unprivileged/blob/main/README.md) for more details)
- [x] I have updated any relevant documentation ([`README`](https://github.com/nginxinc/docker-nginx-unprivileged/blob/main/README.md))
