### PR TITLE
Fix broken links in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,7 @@ The following is a set of guidelines for contributing to the Docker Unprivileged
 
 [Ask a Question](#ask-a-question)
 
-[Getting Started](#getting-started)
+[Getting Started](#project-overview)
 
 [Contributing](#contributing)
 
@@ -34,7 +34,7 @@ To report a bug, open an issue on GitHub with the label `bug` using the availabl
 
 ### Report a Security vulnerability
 
-To report a security vulnerability, open an issue on GitHub with the label `security` using the available security report issue template. Please ensure the security vulnerability directly impacts one of the NGINX dependencies listed in the [`SECURITY`](https://github.com/nginxinc/docker-nginx-unprivileged/blob/main/.github/SECURITY.md) doc. Other security vulnerabilities should be addressed by the weekly Monday night build and as such will be promptly closed.
+To report a security vulnerability, open an issue on GitHub with the label `security` using the available security report issue template. Please ensure the security vulnerability directly impacts one of the NGINX dependencies listed in the [`SECURITY`](https://github.com/nginxinc/docker-nginx-unprivileged/blob/main/SECURITY.md) doc. Other security vulnerabilities should be addressed by the weekly Monday night build and as such will be promptly closed.
 
 ### Suggest a Feature or Enhancement
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,7 @@ The following is a set of guidelines for contributing to the Docker Unprivileged
 
 [Ask a Question](#ask-a-question)
 
-[Getting Started](#project-overview)
+[Project Overview](#project-overview)
 
 [Contributing](#contributing)
 


### PR DESCRIPTION
### Proposed changes

Fix broken links in `CONTRIBUTING.md`

### Checklist

Before creating a PR, run through this checklist and mark each as complete:

- [x] I have read the [`CONTRIBUTING`](https://github.com/nginxinc/docker-nginx-unprivileged/blob/main/CONTRIBUTING.md) document
- [x] I have run `./update.sh` and ensured all entrypoint/Dockerfile template changes have been applied to the relevant image entrypoint scripts & Dockerfiles
- [x] I have tested that the NGINX Unprivileged Docker images build and run correctly on all supported architectures on an unprivileged environment (check out the [`README`](https://github.com/nginxinc/docker-nginx-unprivileged/blob/main/README.md) for more details)
- [x] I have updated any relevant documentation ([`README`](https://github.com/nginxinc/docker-nginx-unprivileged/blob/main/README.md))
